### PR TITLE
Add dummy data

### DIFF
--- a/client/src/dummyData/productsList.js
+++ b/client/src/dummyData/productsList.js
@@ -1,0 +1,85 @@
+// This is the response returned from a GET request to the following endpoint:
+// https://app-hrsei-api.herokuapp.com/api/fec2/hr-den/products
+
+export const productList = [
+  {
+      "id": 44388,
+      "campus": "hr-den",
+      "name": "Camo Onesie",
+      "slogan": "Blend in to your crowd",
+      "description": "The So Fatigues will wake you up and fit you in. This high energy camo will have you blending in to even the wildest surroundings.",
+      "category": "Jackets",
+      "default_price": "140.00",
+      "created_at": "2021-08-13T14:40:29.181Z",
+      "updated_at": "2021-08-13T14:40:29.181Z"
+  },
+  {
+      "id": 44389,
+      "campus": "hr-den",
+      "name": "Bright Future Sunglasses",
+      "slogan": "You've got to wear shades",
+      "description": "Where you're going you might not need roads, but you definitely need some shades. Give those baby blues a rest and let the future shine bright on these timeless lenses.",
+      "category": "Accessories",
+      "default_price": "69.00",
+      "created_at": "2021-08-13T14:40:29.181Z",
+      "updated_at": "2021-08-13T14:40:29.181Z"
+  },
+  {
+      "id": 44390,
+      "campus": "hr-den",
+      "name": "Morning Joggers",
+      "slogan": "Make yourself a morning person",
+      "description": "Whether you're a morning person or not.  Whether you're gym bound or not.  Everyone looks good in joggers.",
+      "category": "Pants",
+      "default_price": "40.00",
+      "created_at": "2021-08-13T14:40:29.181Z",
+      "updated_at": "2021-08-13T14:40:29.181Z"
+  },
+  {
+      "id": 44391,
+      "campus": "hr-den",
+      "name": "Slacker's Slacks",
+      "slogan": "Comfortable for everything, or nothing",
+      "description": "I'll tell you how great they are after I nap for a bit.",
+      "category": "Pants",
+      "default_price": "65.00",
+      "created_at": "2021-08-13T14:40:29.181Z",
+      "updated_at": "2021-08-13T14:40:29.181Z"
+  },
+  {
+      "id": 44392,
+      "campus": "hr-den",
+      "name": "Heir Force Ones",
+      "slogan": "A sneaker dynasty",
+      "description": "Now where da boxes where I keep mine? You should peep mine, maybe once or twice but never three times. I'm just a sneaker pro, I love Pumas and shell toes, but can't nothin compare to a fresh crispy white pearl",
+      "category": "Kicks",
+      "default_price": "99.00",
+      "created_at": "2021-08-13T14:40:29.181Z",
+      "updated_at": "2021-08-13T14:40:29.181Z"
+  }
+];
+
+// A product_url parameter can be added to filter the results to a specific product - e.g.:
+// https://app-hrsei-api.herokuapp.com/api/fec2/hr-den/products/44388
+// returns the following:
+export const singleProduct = {
+    "id": 44388,
+    "campus": "hr-den",
+    "name": "Camo Onesie",
+    "slogan": "Blend in to your crowd",
+    "description": "The So Fatigues will wake you up and fit you in. This high energy camo will have you blending in to even the wildest surroundings.",
+    "category": "Jackets",
+    "default_price": "140.00",
+    "created_at": "2021-08-13T14:40:29.181Z",
+    "updated_at": "2021-08-13T14:40:29.181Z",
+    "features": [
+        {
+            "feature": "Fabric",
+            "value": "Canvas"
+        },
+        {
+            "feature": "Buttons",
+            "value": "Brass"
+        }
+    ]
+};

--- a/client/src/dummyData/reviewsList.js
+++ b/client/src/dummyData/reviewsList.js
@@ -1,0 +1,47 @@
+// This is the data that should theoretically get returned from:
+// https://app-hrsei-api.herokuapp.com/api/fec2/hr-den/reviews?product_id=5
+// In reality there are currently no results in the results array...
+// My guess is that the results will get populated by us posting reviews for products
+// This data is the example provided by Learn so we can work off it for now
+
+export const reviewsList = {
+  "product": "2",
+  "page": 0,
+  "count": 5,
+  "results": [
+    {
+      "review_id": 5,
+      "rating": 3,
+      "summary": "I'm enjoying wearing these shades",
+      "recommend": false,
+      "response": null,
+      "body": "Comfortable and practical.",
+      "date": "2019-04-14T00:00:00.000Z",
+      "reviewer_name": "shortandsweeet",
+      "helpfulness": 5,
+      "photos": [{
+          "id": 1,
+          "url": "urlplaceholder/review_5_photo_number_1.jpg"
+        },
+        {
+          "id": 2,
+          "url": "urlplaceholder/review_5_photo_number_2.jpg"
+        },
+        // ...
+      ]
+    },
+    {
+      "review_id": 3,
+      "rating": 4,
+      "summary": "I am liking these glasses",
+      "recommend": false,
+      "response": "Glad you're enjoying the product!",
+      "body": "They are very dark. But that's good because I'm in very sunny spots",
+      "date": "2019-06-23T00:00:00.000Z",
+      "reviewer_name": "bigbrotherbenjamin",
+      "helpfulness": 5,
+      "photos": [],
+    },
+    // ...
+  ]
+}

--- a/client/src/dummyData/reviewsMetadata.js
+++ b/client/src/dummyData/reviewsMetadata.js
@@ -1,0 +1,31 @@
+// This is the data that should theoretically get returned from:
+//https://app-hrsei-api.herokuapp.com/api/fec2/hr-den/reviews/meta?product_id=2
+// See reviewsList.js for more explanation
+
+export const reviewsMeta = {
+  "product_id": "2",
+  "ratings": {
+    2: 1,
+    3: 1,
+    4: 2,
+    // ...
+  },
+  "recommended": {
+    0: 5
+    // ...
+  },
+  "characteristics": {
+    "Size": {
+      "id": 14,
+      "value": "4.0000"
+    },
+    "Width": {
+      "id": 15,
+      "value": "3.5000"
+    },
+    "Comfort": {
+      "id": 16,
+      "value": "4.0000"
+    },
+    // ...
+}


### PR DESCRIPTION
I got some API data that we can use to start building our frontend without having to make endless API calls.

You can see the data in **client/src/dummyData/.**

the folder contains 3 files, each corresponding to a certain endpoint. The files have named exports which can imported into component files for the time being, e.g.: 
**import { productList } from "../dummyData/productsList.js"**