### PR TITLE
implement server forwarding

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,13 +1,39 @@
+// Libraries
 const express = require('express');
+const axios = require('axios');
 const path = require('path');
 
-const server = express();
+// API
+const baseUrl = 'https://app-hrsei-api.herokuapp.com/api/fec2/hr-den';
+const { auth } = require('./config.js');
 
+// Server Config
+const server = express();
 server.use(express.json());
 server.use(express.urlencoded());
 server.use(express.static( path.resolve(__dirname, '..', 'client', 'dist')) );
-
+axios.defaults.headers.common['Authorization'] = auth;
 var port = 3000;
+
+server.use('/', (req, res, next) =>{
+
+  console.log(`\nReceived ${req.method} request at endpoint: ${req.path}\nRequest body:`);
+  console.log(req.body);
+  let url = baseUrl + req.path;
+  console.log(`\nSending API ${req.method} request: \n${url}`);
+
+  axios({
+    method: req.method,
+    url: url,
+    data: req.body
+  })
+  .then( apiRes => {
+    console.log('\nAPI response body:');
+    console.log( apiRes.data );
+    res.status( apiRes.status ).send(apiRes.data);
+  });
+
+});
 
 server.listen(port, () => {
   console.log('Server running on ', port);


### PR DESCRIPTION
This PR successfully implements server forwarding:
- Requests can be made from the frontend (or postman) to the local server (assuming local server is live)
- local server will automatically attach authorization header, then forward the request to the Hack Reactor API.
- Data returned from the Hack Reactor API will then be sent back to the requester, both the status code and response body duplicated from the APIs response to the server
---
**NOTE**: The server assumes there is a valid GH token in `server/config.js`, exported as `module.exports.auth`. This token isn't included in version control and must be added in order for forwarding to be successful