### PR TITLE
Start add cart

### DIFF
--- a/client/src/components/Overview/AddToCart/AddToCart.jsx
+++ b/client/src/components/Overview/AddToCart/AddToCart.jsx
@@ -1,0 +1,32 @@
+// React
+import React from 'react';
+
+// Utilities
+import { serverRequests } from '../../../utils/serverRequests';
+
+// Stylesheet
+import './AddToCart.css'
+
+export const AddToCart = (props) =>{
+
+  const {sku, qty} = props;
+
+  function clickHandler(){
+    if (props.statusListener){
+      props.statusListener( serverRequests.addToCart(sku[0], qty) );
+    } else {
+      serverRequests.addToCart(sku[0], qty);
+    }
+  }
+
+  return (
+    <button
+      id='add-cart'
+      data-testid='add-cart'
+      onClick={clickHandler}
+      disabled={ !sku || !qty }
+    >
+      ADD TO BAG
+    </button>
+  );
+};

--- a/client/src/components/Overview/AddToCart/AddToCart.test.js
+++ b/client/src/components/Overview/AddToCart/AddToCart.test.js
@@ -1,0 +1,46 @@
+// Libraries
+import React from 'react';
+import {render, screen, fireEvent} from '@testing-library/react';
+
+// Components
+import { AddToCart } from './AddToCart.jsx';
+
+describe("Add To Cart", ()=>{
+
+  it('should be a button', ()=>{
+    render( <AddToCart /> );
+    let addCart = screen.queryByTestId( 'add-cart' );
+    expect( addCart.nodeName ).toBe('BUTTON');
+  });
+
+  it('if no valid style and quantity selected, button should be disabled', ()=>{
+    render( <AddToCart /> );
+    let addCart = screen.queryByTestId( 'add-cart' );
+    expect( addCart.disabled ).toBe(true);
+  });
+
+// IMPORTANT NOTE:
+// The test below (click "ADD TO BAG" button) has been tested and is passing as of 9.15.21 5:36pm
+// It is now x'd out so as not to run API calls every time the test suites are ran
+// In order to test that this behavior is still functioning properly, change the "xit" to "it"
+  xit('if valid size and qty are selected, clicking will add to cart', ()=>{
+
+    let sku = [
+      "1549625",
+      { "quantity": 17, "size": "M" }
+    ];
+
+    let statusState = null;
+    let statusSetter = function(status) { statusState = status };
+
+    render( <AddToCart sku={sku} qty={5} statusListener={statusSetter} /> );
+    let addCart = screen.queryByTestId( 'add-cart' );
+    fireEvent.click(addCart);
+    return statusState.then( response => {
+      expect( response ).toBe( 'Created' );
+    });
+  });
+
+  test.todo('if "Select Size" is selected: clicking should open size dropdown - also gives message "Please select a size"');
+
+});

--- a/client/src/components/Overview/Overview.jsx
+++ b/client/src/components/Overview/Overview.jsx
@@ -6,6 +6,7 @@ import { QtySelector } from './QtySelector/QtySelector.jsx';
 import { SizeSelector } from './SizeSelector/SizeSelector.jsx';
 import { StyleSelector } from './StyleSelector/StyleSelector.jsx';
 import { Price } from './Price/Price.jsx';
+import { AddToCart } from './AddToCart/AddToCart.jsx';
 import { StarRating } from '../StarRating/StarRating.jsx';
 
 //Style Sheet
@@ -18,6 +19,7 @@ export const Overview = (props) =>{
 
   const [currentStyle, setCurrentStyle] = useState(null);
   const [currentSize, setCurrentSize] = useState(null);
+  const [currentSku, setCurrentSku] = useState(null);
   const [currentQty, setCurrentQty] = useState(null);
 
   return(
@@ -43,14 +45,17 @@ export const Overview = (props) =>{
             <SizeSelector
               skus={currentStyle ? currentStyle.skus : null}
               setSize={setCurrentSize}
+              setSku={setCurrentSku}
             />
             <QtySelector
-              size={currentSize}
-              skus={currentStyle ? currentStyle.skus : null}
+              sku={currentSku}
               setQty={setCurrentQty}
             />
           </div>
-          <button id='add-cart'>ADD TO BAG</button>
+          <AddToCart
+            sku={currentSku}
+            qty={currentQty}
+          />
         </div>
 
       </div>

--- a/client/src/components/Overview/Overview.test.js
+++ b/client/src/components/Overview/Overview.test.js
@@ -33,7 +33,8 @@ describe("Overview", ()=>{
   [
     'select-style',
     'select-size',
-    'prod-price'
+    'prod-price',
+    'add-cart'
   ].forEach( element => {
 
     it(`Renders a ${element} component`, ()=>{
@@ -44,18 +45,6 @@ describe("Overview", ()=>{
 
   });
 
-  describe("Add To Cart", ()=>{
 
-    it('should exist', ()=>{
-      render( <Overview product={product} styles={styles} /> );
-      let addButton = screen.getByText('ADD TO BAG');
-      expect( addButton ).toBeTruthy();
-    })
-
-    test.todo('should be a button');
-    test.todo('if "Select Size" is selected: clicking should open size dropdown - also gives message "Please select a size"');
-    test.todo('if no stock, button should be hidden');
-    test.todo('if valid size and qty are selected, clicking will add to cart');
-  });
 
 });

--- a/client/src/components/Overview/Price/Price.test.js
+++ b/client/src/components/Overview/Price/Price.test.js
@@ -1,7 +1,6 @@
 // Libraries
 import React from 'react';
 import {render, screen} from '@testing-library/react';
-import {toHaveStyle} from '@testing-library/jest-dom/extend-expect'
 
 // Components
 import { Price } from './Price.jsx';

--- a/client/src/components/Overview/QtySelector/QtySelector.jsx
+++ b/client/src/components/Overview/QtySelector/QtySelector.jsx
@@ -5,7 +5,7 @@ import React, {useState} from 'react';
 import './QtySelector.css'
 
 export const QtySelector = (props) =>{
-  const {size, skus} = props;
+  const {sku} = props;
 
   function handleChange(e){
     props.setQty( Number(e.target.value) );
@@ -31,7 +31,7 @@ export const QtySelector = (props) =>{
 
   let renderOptions = function() {
 
-    let max = getMaxQty(size, skus);
+    let max = sku.quantity < 15 ? sku.quantity : 15;
     let i = 1;
     let options = [];
 
@@ -48,14 +48,14 @@ export const QtySelector = (props) =>{
 
   return (
     <select
-      defaultValue={size ? '1' : '-'}
-      disabled={!size ? true : false}
+      defaultValue={sku ? '1' : '-'}
+      disabled={!sku ? true : false}
       data-testid='QtySelector'
       onChange={handleChange}
     >
 
       {
-        size && skus ?
+        sku ?
         renderOptions()
         :
         <option value='-'>-</option>

--- a/client/src/components/Overview/QtySelector/QtySelector.test.js
+++ b/client/src/components/Overview/QtySelector/QtySelector.test.js
@@ -31,7 +31,7 @@ describe("Quantity Selector", ()=>{
       { quantity: 2, size: 'L' },
     ];
 
-    render( <QtySelector size='M' skus={skus} /> );
+    render( <QtySelector sku={skus[0]} /> );
     let qtySelector = screen.queryByTestId( 'QtySelector' );
     expect( qtySelector.value ).toBe( '1' );
   });
@@ -46,7 +46,7 @@ describe("Quantity Selector", ()=>{
     render(
       <QtySelector
         size='M'
-        skus={skus}
+        sku={skus[0]}
       />
     );
 
@@ -66,15 +66,14 @@ describe("Quantity Selector", ()=>{
 
   it('if more than 15 are in stock, max should be limited to 15', ()=>{
 
-    let skus = [
-      { quantity: 25, size: 'M' },
-      { quantity: 2, size: 'L' },
+    let sku = [
+      { quantity: 25, size: 'M' }
     ];
 
     render(
       <QtySelector
         size='M'
-        skus={skus}
+        sku={sku}
       />
     );
 
@@ -101,7 +100,7 @@ describe("Quantity Selector", ()=>{
     render(
       <QtySelector
         size='M'
-        skus={skus}
+        sku={skus[0]}
         setQty={qtySetter}
       />
     );

--- a/client/src/components/Overview/SizeSelector/SizeSelector.jsx
+++ b/client/src/components/Overview/SizeSelector/SizeSelector.jsx
@@ -6,10 +6,17 @@ import './SizeSelector.css'
 
 export const SizeSelector = (props) =>{
 
-  let { skus } = props;
+  let { skus, setSize, setSku } = props;
 
   function handleChange(e){
-    props.setSize(e.target.value);
+
+    let sku = Object.keys(skus).find( sku =>{
+      let currentSku = skus[sku];
+      return currentSku.size === e.target.value;
+    })
+
+    setSize(e.target.value);
+    setSku( [ sku, skus[sku] ]);
   }
 
   let sizes = function getSizes(skus){

--- a/client/src/components/Overview/SizeSelector/SizeSelector.test.js
+++ b/client/src/components/Overview/SizeSelector/SizeSelector.test.js
@@ -99,7 +99,7 @@ describe("Size Selector", ()=>{
   });
 
 
-  it('should call state setter function on change', ()=>{
+  it('should call size state setter function on change', ()=>{
 
     let sizeState = null;
 
@@ -107,12 +107,35 @@ describe("Size Selector", ()=>{
       sizeState = selectedSize;
     }
 
-    render( <SizeSelector skus={skus} setSize={sizeSetter} /> );
+    render( <SizeSelector skus={skus} setSize={sizeSetter} setSku={()=>{}} /> );
 
     let sizeSelector = screen.queryByTestId( 'select-size' );
     fireEvent.change( sizeSelector, {target: {value: 'XL'}} );
 
     expect(sizeState).toBe('XL');
+
+  });
+
+  it('should call sku state setter function on change', ()=>{
+
+    let skuState = null;
+
+    let skuSetter = (selectedSku) => {
+      skuState = selectedSku;
+    }
+
+    render(
+      <SizeSelector
+        skus={skus}
+        setSku={skuSetter}
+        setSize={()=>{}}
+      />
+    );
+
+    let sizeSelector = screen.queryByTestId( 'select-size' );
+    fireEvent.change( sizeSelector, {target: {value: 'XS'}} );
+
+    expect(skuState[0]).toBe("1549611");
 
   });
 


### PR DESCRIPTION
- Basic functionality for the 'Add To Cart' button
  - should be a button
  - disabled without required selections
  - with valid selections - adds product to cart via API
- **TESTS:** passing tests confirming the above behavior
---
- **also included:** slight refactor of other Overview components - changes how SKU is chosen