### PR TITLE
cleanup post-refactor

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -24,15 +24,8 @@ import { parseQueries } from './utils/parseQueries';
 
 export const App = (props) => {
 
-  let productId = 44388;
-  let queries;
-
-  if (useParams()){
-    productId = useParams().productId;
-  }
-  if ( useLocation() ){
-    queries = parseQueries( queries = useLocation().search );
-  }
+  let productId = useParams().productId || 44388;
+  let queries = parseQueries( useLocation().search );
 
   let [currentProduct, setCurrentProduct] = useState(null);
   let [reviewsMetadata, setReviewsMetadata] = useState(null);
@@ -52,7 +45,6 @@ export const App = (props) => {
 
   useEffect( ()=>{
     if (queryParams.noDummy){
-      console.log('no dummy');
       fetchProductData();
       fetchReviewsMeta();
     } else {

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {render, screen} from '@testing-library/react';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
 
 import {App} from './App.jsx';
 import { RatingsReviews } from './components/RatingsReviews/RatingsReviews.jsx';
@@ -13,7 +14,11 @@ jest.mock('./components/RatingsReviews/RatingsReviews.jsx', () => {
 
 describe("App", ()=>{
 
-  const {container} = render( <App/> );
+  const {container} = render(
+    <Router>
+      <App/>
+    </Router>
+  );
 
   it("Renders without crashing", ()=>{
 
@@ -23,7 +28,11 @@ describe("App", ()=>{
   });
 
   it(`Renders each major widget`, ()=>{
-    render( <App/> );
+    render(
+      <Router>
+        <App/>
+      </Router>
+    );
 
     [
       'Overview',

--- a/client/src/utils/parseQueries.js
+++ b/client/src/utils/parseQueries.js
@@ -1,31 +1,34 @@
 export function parseQueries(queryString){
 
   let queryArgs = {};
-  let i = 1;
-  let query = [undefined, undefined];
-  let unparsed = queryString.slice(0);
 
-  while( i < unparsed.length ){
+  if (queryString){
+    let i = 1;
+    let query = [undefined, undefined];
+    let unparsed = queryString.slice(0);
 
-    if (unparsed[i] === '='){
-      query[0] = unparsed.slice(1,i);
-      unparsed = unparsed.slice(i);
-      i = 0;
+    while( i < unparsed.length ){
 
-    } else if (unparsed[i] === '&'){
-      query[1] = unparsed.slice(1,i);
-      queryArgs[query[0]] = query[1];
-      unparsed = unparsed.slice(i);
-      query = [undefined, undefined];
-      i = 0;
+      if (unparsed[i] === '='){
+        query[0] = unparsed.slice(1,i);
+        unparsed = unparsed.slice(i);
+        i = 0;
+
+      } else if (unparsed[i] === '&'){
+        query[1] = unparsed.slice(1,i);
+        queryArgs[query[0]] = query[1];
+        unparsed = unparsed.slice(i);
+        query = [undefined, undefined];
+        i = 0;
+      }
+      i++;
     }
-    i++;
-  }
-  if (query[0] && !query[1]){
-    query[1] = unparsed.slice(1);
-    queryArgs[query[0]] = query[1];
-  } else if (!query[0]){
-    queryArgs[unparsed.slice(1)] = 'true';
+    if (query[0] && !query[1]){
+      query[1] = unparsed.slice(1);
+      queryArgs[query[0]] = query[1];
+    } else if (!query[0]){
+      queryArgs[unparsed.slice(1)] = 'true';
+    }
   }
   return queryArgs;
 }

--- a/server/index.js
+++ b/server/index.js
@@ -19,8 +19,6 @@ var port = 3000;
 // API Forwarding
 server.use('/api/', (req, res, next) =>{
 
-  console.log(req.path.slice(3) );
-
   console.log(`\nReceived ${req.method} request at endpoint: ${req.path}\nRequest body:`);
   console.log(req.body);
   console.log('req.query', req.query);

--- a/server/index.js
+++ b/server/index.js
@@ -16,23 +16,7 @@ server.use(express.json());
 server.use(express.urlencoded());
 var port = 3000;
 
-server.use( (req,res,next) =>{
-  console.log(req.path);
-  next();
-});
-
-server.use('*/bundle.js', (req, res)=>{
-  res.sendFile( path.resolve(__dirname, '..', 'client', 'dist', 'bundle.js') );
-});
-server.use('*/bundle.css', (req, res)=>{
-  res.sendFile( path.resolve(__dirname, '..', 'client', 'dist', 'bundle.css') );
-});
-server.use('*/reset.css', (req, res)=>{
-  res.sendFile( path.resolve(__dirname, '..', 'client', 'dist', 'reset.css') );
-});
-
-server.use('/products', express.static( path.resolve(__dirname, '..', 'client', 'dist')) );
-
+// API Forwarding
 server.use('/api/', (req, res, next) =>{
 
   console.log(req.path.slice(3) );
@@ -42,7 +26,6 @@ server.use('/api/', (req, res, next) =>{
   console.log('req.query', req.query);
   let url = baseUrl + req.path;
   console.log(`\nSending API ${req.method} request: \n${url}`);
-
 
   axios({
     method: req.method,
@@ -59,13 +42,19 @@ server.use('/api/', (req, res, next) =>{
 
 });
 
-server.use('/', express.static( path.resolve(__dirname, '..', 'client', 'dist')) );
-
+// React App Static Files
+server.get('*/bundle.js', (req, res)=>{
+    res.sendFile( path.resolve(__dirname, '..', 'client', 'dist', 'bundle.js') );
+});
+server.get('*/bundle.css', (req, res)=>{
+    res.sendFile( path.resolve(__dirname, '..', 'client', 'dist', 'bundle.css') );
+});
+server.get('*/reset.css', (req, res)=>{
+    res.sendFile( path.resolve(__dirname, '..', 'client', 'dist', 'reset.css') );
+});
 server.get('*', (req, res, next) => {
-  console.log(req.path);
   res.sendFile( path.resolve(__dirname, '..', 'client', 'dist', 'index.html') );
 });
-
 
 server.listen(port, () => {
   console.log('Server running on ', port);


### PR DESCRIPTION
- In ```App.test.js``` - render ```<App/>``` inside ```<Router/>``` to avoid errors (matches rendering in ```client/index.js```)
- In ```App.jsx``` - tweak parameter and query definition
- In ```parseQueries.js``` - handle cases with no queries
- In ```server.js``` - reorganize static file service