### PR TITLE
the actual deploy commands should not be tracked by git.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,7 @@ jobs:
 workflows:
   "Run tests on PRs":
     jobs:
-      - test:
-          filters:
-            branches:
-              only: /^(pull\/).*$/
+      - test
   "Deploy to machine":
     jobs:
       - deploy:

--- a/pull_and_deploy.sh
+++ b/pull_and_deploy.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-cd "$(dirname "${BASH_SOURCE[0]}")"
-npx forever stopall
-git pull origin release
-git switch release
-npm i
-npx forever start server


### PR DESCRIPTION
the actual steps to deploy can differ depending on environment, so leave those details to a person.
Also, a .sh script would need to have its permissions modified to become executable anyways, so a person would
need to take steps and automate that part anyways.